### PR TITLE
Add display name requirement and hide personal names

### DIFF
--- a/src/app/post/[id]/[slug]/page.tsx
+++ b/src/app/post/[id]/[slug]/page.tsx
@@ -86,7 +86,7 @@ function CommentCard({ comment: initialComment, postId, onCommentDeleted, onComm
   }
 
 
-  const authorDisplayName = comment.author?.displayName || comment.author?.name || 'Anonymous';
+  const authorDisplayName = comment.author?.displayName || 'Anonymous';
   const authorAvatar = comment.author?.avatarUrl;
   const authorAvatarFallback = authorDisplayName.substring(0,1).toUpperCase();
 
@@ -329,12 +329,11 @@ export default function PostPage({ params }: { params: PostPageParams }) {
 
     setIsSubmittingComment(true);
     try {
-      const authorInfo: AuthorInfo = { // Ensure AuthorInfo matches the type, including displayName
-        uid: user.uid,
-        name: user.name,
-        displayName: user.displayName || user.name, // Use displayName or fallback to name
-        avatarUrl: user.avatarUrl,
-      };
+        const authorInfo: AuthorInfo = {
+          uid: user.uid,
+          displayName: user.displayName,
+          avatarUrl: user.avatarUrl,
+        };
       const commentToCreate: Omit<CommentType, 'id' | 'createdAt' | 'updatedAt' | 'likes'> = {
         postId: post.id,
         author: authorInfo,
@@ -411,7 +410,7 @@ export default function PostPage({ params }: { params: PostPageParams }) {
     }
   }
 
-  const authorDisplayName = post.author?.displayName || post.author?.name || 'Anonymous';
+  const authorDisplayName = post.author?.displayName || 'Anonymous';
   const authorAvatar = post.author?.avatarUrl;
   const authorAvatarFallback = authorDisplayName.substring(0,1).toUpperCase();
   const canModifyPost = user && (user.uid === post.author?.uid || user.role === 'superuser' || user.role === 'moderator');

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -17,7 +17,8 @@ export function AuthForm() {
   const [loginPassword, setLoginPassword] = useState('');
   const [registerEmail, setRegisterEmail] = useState('');
   const [registerPassword, setRegisterPassword] = useState('');
-  const [registerName, setRegisterName] = useState(''); // This will be used for name and initial displayName
+  const [registerDisplayName, setRegisterDisplayName] = useState('');
+  const [registerName, setRegisterName] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [authAction, setAuthAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -52,8 +53,7 @@ export function AuthForm() {
     setAuthAction('email');
     setError(null);
     try {
-      // Pass registerName to be used as both 'name' and initial 'displayName'
-      await register(registerEmail, registerPassword, registerName);
+      await register(registerEmail, registerPassword, registerDisplayName, registerName || null);
       toast({ title: "Registration Successful", description: "Welcome to GuernseySpeaks! Please set up your profile." });
       router.push(redirectPath); // Redirect to profile page
     } catch (err: any) {
@@ -151,8 +151,18 @@ export function AuthForm() {
             <form onSubmit={handleRegister}>
               <CardContent className="space-y-4">
                 <div className="space-y-2">
+                  <Label htmlFor="register-display-name">Display Name</Label>
+                  <Input
+                    id="register-display-name"
+                    placeholder="cooluser123"
+                    required
+                    value={registerDisplayName}
+                    onChange={(e) => setRegisterDisplayName(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
                   <Label htmlFor="register-name">Full Name</Label>
-                  <Input id="register-name" placeholder="John Doe" required value={registerName} onChange={(e) => setRegisterName(e.target.value)} />
+                  <Input id="register-name" placeholder="John Doe" value={registerName} onChange={(e) => setRegisterName(e.target.value)} />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="register-email">Email</Label>

--- a/src/components/posts/post-card.tsx
+++ b/src/components/posts/post-card.tsx
@@ -78,7 +78,7 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
   }
 
   const postSlug = post.slug || post.title.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]+/g, '');
-  const authorDisplayName = post.author?.displayName || post.author?.name || 'Anonymous';
+  const authorDisplayName = post.author?.displayName || 'Anonymous';
   const authorAvatar = post.author?.avatarUrl;
   const authorAvatarFallback = authorDisplayName.substring(0,1).toUpperCase();
 

--- a/src/components/posts/post-form.tsx
+++ b/src/components/posts/post-form.tsx
@@ -81,8 +81,7 @@ export function PostForm({ postToEdit }: PostFormProps) {
       } else {
         const authorInfo: AuthorInfo = {
           uid: user.uid,
-          name: user.name, // User's full name
-          displayName: user.displayName || user.name, // User's display name, fallback to name
+          displayName: user.displayName,
           avatarUrl: user.avatarUrl,
         };
         const newPostPayload = {

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -21,7 +21,12 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
-  register: (email: string, password: string, name: string) => Promise<void>; // name is for both name and initial displayName
+  register: (
+    email: string,
+    password: string,
+    displayName: string,
+    name?: string | null
+  ) => Promise<void>;
   signInWithGoogle: () => Promise<void>;
   signInWithFacebook: () => Promise<void>;
   logout: () => Promise<void>;
@@ -87,7 +92,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const register = async (email: string, password: string, name: string) => {
+  const register = async (
+    email: string,
+    password: string,
+    displayName: string,
+    name?: string | null
+  ) => {
     setLoading(true);
     try {
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
@@ -95,9 +105,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const newUserProfile: User = {
         uid: firebaseUser.uid,
         email: firebaseUser.email,
-        name: name, // Use provided name
-        displayName: name, // Use provided name as initial displayName
-        avatarUrl: `https://placehold.co/40x40.png?text=${name.substring(0,1)}`,
+        name: name || null,
+        displayName,
+        avatarUrl: `https://placehold.co/40x40.png?text=${displayName.substring(0,1)}`,
         role: 'user',
         createdAt: serverTimestamp() as Timestamp,
       };
@@ -119,7 +129,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         uid: firebaseUser.uid,
         email: firebaseUser.email,
         name: newName,
-        displayName: newName, // Set displayName same as name initially
+        displayName: null,
         avatarUrl: firebaseUser.photoURL || `https://placehold.co/40x40.png?text=${newName.substring(0,1)}`,
         role: 'user',
         createdAt: serverTimestamp() as Timestamp,
@@ -134,7 +144,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             email: firebaseUser.email,
             avatarUrl: firebaseUser.photoURL || userData.avatarUrl,
             name: userData.name || firebaseUser.displayName,
-            displayName: userData.displayName || userData.name || firebaseUser.displayName,
+            displayName: userData.displayName || firebaseUser.displayName || null,
           });
     }
   };

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -34,11 +34,10 @@ interface CreatePostInputData {
 export async function createPost(postData: CreatePostInputData): Promise<string> {
   try {
     const slug = await generateSlug(postData.title);
-    // Ensure author info includes displayName, falling back to name
-    const author: AuthorInfo = {
+    // Only include public author information
+  const author: AuthorInfo = {
         uid: postData.author.uid,
-        name: postData.author.name,
-        displayName: postData.author.displayName || postData.author.name,
+        displayName: postData.author.displayName,
         avatarUrl: postData.author.avatarUrl
     };
 
@@ -159,15 +158,13 @@ export async function togglePostLike(postId: string, userId: string): Promise<{ 
   }
 };
 
-// Note: Comment author info now includes displayName
+// Store only public comment author information
 export async function createComment(postId: string, commentData: Omit<Comment, 'id' | 'createdAt' | 'updatedAt' | 'likes'>): Promise<string> {
   try {
     const commentsCollectionRef = collection(db, 'posts', postId, 'comments');
-     // Ensure author info includes displayName, falling back to name
     const author: AuthorInfo = {
         uid: commentData.author.uid,
-        name: commentData.author.name,
-        displayName: commentData.author.displayName || commentData.author.name,
+        displayName: commentData.author.displayName,
         avatarUrl: commentData.author.avatarUrl
     };
     const docRef = await addDoc(commentsCollectionRef, {


### PR DESCRIPTION
## Summary
- require display name when registering
- update authentication context to store/display display name only
- create posts and comments using display names only
- hide real names on posts and comments

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683e0e98cf648329b907b64b53a7f995