### PR TITLE
Add RSS news fetcher

### DIFF
--- a/src/app/api/fetch-news/route.ts
+++ b/src/app/api/fetch-news/route.ts
@@ -1,0 +1,84 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+
+interface CustomNewsArticle {
+  sourceName: string;
+  title: string;
+  url: string;
+  publishedDate?: string;
+  description?: string;
+}
+
+const FEEDS = [
+  {
+    sourceName: 'Bailiwick Express',
+    url: 'https://www.bailiwickexpress.com/feeds/news/',
+  },
+  {
+    sourceName: 'Guernsey Press',
+    url: 'https://guernseypress.com/feed/',
+  },
+];
+
+function extractFirst(item: string, regexes: RegExp[]): string | undefined {
+  for (const regex of regexes) {
+    const match = item.match(regex);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+  return undefined;
+}
+
+function parseRss(xml: string, sourceName: string, limit: number = 5): CustomNewsArticle[] {
+  const items = xml.match(/<item>([\s\S]*?)<\/item>/gi) || [];
+  const articles: CustomNewsArticle[] = [];
+  for (const itemRaw of items.slice(0, limit)) {
+    const title = extractFirst(itemRaw, [
+      /<title><!\[CDATA\[(.*?)\]\]><\/title>/i,
+      /<title>(.*?)<\/title>/i,
+    ]);
+    const url = extractFirst(itemRaw, [
+      /<link>(.*?)<\/link>/i,
+    ]);
+    const publishedDate = extractFirst(itemRaw, [
+      /<pubDate>(.*?)<\/pubDate>/i,
+    ]);
+    const description = extractFirst(itemRaw, [
+      /<description><!\[CDATA\[(.*?)\]\]><\/description>/i,
+      /<description>(.*?)<\/description>/i,
+    ]);
+
+    if (title && url) {
+      articles.push({
+        sourceName,
+        title,
+        url,
+        publishedDate,
+        description,
+      });
+    }
+  }
+  return articles;
+}
+
+export async function GET() {
+  const articles: CustomNewsArticle[] = [];
+
+  for (const feed of FEEDS) {
+    try {
+      const res = await fetch(feed.url, { next: { revalidate: 3600 } });
+      if (!res.ok) {
+        console.error(`Failed to fetch ${feed.sourceName}: ${res.status}`);
+        continue;
+      }
+      const xml = await res.text();
+      articles.push(...parseRss(xml, feed.sourceName));
+    } catch (err) {
+      console.error(`Error fetching ${feed.sourceName}:`, err);
+    }
+  }
+
+  return NextResponse.json({ articles });
+}

--- a/src/components/news-headlines-widget.tsx
+++ b/src/components/news-headlines-widget.tsx
@@ -24,60 +24,18 @@ export function NewsHeadlinesWidget() {
     async function fetchCustomNews() {
       setLoading(true);
       setError(null);
-      setArticles([]); // Clear previous articles
+      setArticles([]);
 
-      // --- Placeholder: Simulate fetching from two websites ---
-      // In a real implementation, this would involve:
-      // 1. Making HTTP requests to the target websites (server-side, e.g., in an API route or Server Action).
-      // 2. Parsing the HTML response (e.g., using a library like 'cheerio' if RSS feeds are not available).
-      // 3. Extracting headlines, links, and other relevant data.
-      // 4. Handling errors for each website individually.
-      // This process is complex and site-specific.
-
-      // For now, we'll use mock data.
       try {
-        // Simulate a delay
-        await new Promise(resolve => setTimeout(resolve, 1000));
-
-        const mockArticles: CustomNewsArticle[] = [
-          {
-            sourceName: "Placeholder Site 1",
-            title: "Important Update from Site 1",
-            url: "#",
-            publishedDate: new Date().toLocaleDateString('en-GB', { day: '2-digit', month: 'short' }),
-            description: "This is a placeholder article description from the first mock website."
-          },
-          {
-            sourceName: "Placeholder Site 1",
-            title: "Another Story from Site 1",
-            url: "#",
-            publishedDate: new Date(Date.now() - 86400000).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' }), // Yesterday
-          },
-          {
-            sourceName: "Placeholder Site 2",
-            title: "Breaking News from Site 2",
-            url: "#",
-            publishedDate: new Date().toLocaleDateString('en-GB', { day: '2-digit', month: 'short' }),
-            description: "Details about the latest developments from the second mock website."
-          },
-          {
-            sourceName: "Placeholder Site 2",
-            title: "Featured Article on Site 2",
-            url: "#",
-          },
-        ];
-        
-        // Simulate a potential error for one site (for demonstration)
-        // if (Math.random() > 0.5) {
-        //   throw new Error("Simulated error fetching from Placeholder Site 2");
-        // }
-
-        setArticles(mockArticles.slice(0, 5)); // Limit to 5 articles
-        setError(null); // Clear any previous error
-
+        const res = await fetch('/api/fetch-news');
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        const data = await res.json();
+        setArticles(data.articles || []);
       } catch (e: any) {
-        console.error("Error fetching custom news (simulated):", e);
-        setError("Could not load news from custom sources. " + e.message);
+        console.error('Error fetching custom news:', e);
+        setError('Could not load news from custom sources. ' + e.message);
         setArticles([]);
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- create `/api/fetch-news` to grab and parse RSS feeds from Bailiwick Express and Guernsey Press
- update `NewsHeadlinesWidget` to call the new endpoint instead of using mock data

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: several TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_6843369134c08329a1e08edd891077fb