### PR TITLE
Switch to xml2js for RSS parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- add `xml2js` dependency
- parse RSS feeds via `xml2js` instead of regex
- update API route to await `parseRss`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_68433f8a6a048329b3c96c77b6c700cd