### PR TITLE
Improve fetch-news API

### DIFF
--- a/src/app/api/fetch-news/route.ts
+++ b/src/app/api/fetch-news/route.ts
@@ -1,5 +1,7 @@
 'use server';
 
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 
 interface CustomNewsArticle {
@@ -68,7 +70,10 @@ export async function GET() {
 
   for (const feed of FEEDS) {
     try {
-      const res = await fetch(feed.url, { next: { revalidate: 3600 } });
+      const res = await fetch(feed.url, {
+        cache: 'no-store',
+        headers: { 'User-Agent': 'GuernseySpeaks/1.0' },
+      });
       if (!res.ok) {
         console.error(`Failed to fetch ${feed.sourceName}: ${res.status}`);
         continue;


### PR DESCRIPTION
## Summary
- mark the `fetch-news` route as dynamic
- add a `User-Agent` header
- disable caching by using `cache: 'no-store'`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68433f7e5d6c8329964896c4afe078e8