### PR TITLE
Fix invalid import line

### DIFF
--- a/src/services/advertisementService.ts
+++ b/src/services/advertisementService.ts
@@ -23,7 +23,6 @@ import {
   getDownloadURL,
   deleteObject,
 } from 'firebase/storage';
-import {ניווט מהיר למאמרים על ידי לחיצה על שם של הכותרת שלהם}
 interface CreateAdvertisementInput {
   title: string;
   linkUrl: string;


### PR DESCRIPTION
## Summary
- remove stray non-ASCII import line from `advertisementService.ts`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: auth-context.tsx has syntax error)*

------
https://chatgpt.com/codex/tasks/task_b_68433f5248508329a1054fa50e91707b