### PR TITLE
Fix Next.js API route build failure

### DIFF
--- a/src/app/api/fetch-news/route.ts
+++ b/src/app/api/fetch-news/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';


### PR DESCRIPTION
## Summary
- remove `'use server'` directive from `fetch-news` API route to avoid build error

## Testing
- `npm install` *(fails: MaxListenersExceededWarning)*

------
https://chatgpt.com/codex/tasks/task_b_68436990ece08329b0d04f0e37ca2ad9