### PR TITLE
Update header and feed layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,16 +91,7 @@ export default function HomePage() {
       weatherWidget={<WeatherWidget />}
       adsWidget={<AdPlaceholder />}
     >
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold">Community Feed</h1>
-        {!authLoading && user && (
-          <Button asChild>
-            <Link href="/submit">
-              <PenSquare className="mr-2 h-5 w-5" /> Create Post
-            </Link>
-          </Button>
-        )}
-      </div>
+
       
       <PostListFilters
         searchTerm={searchTerm}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Home, PlusSquare, LogIn, LogOut, UserCircle, Loader2, ShieldCheck } from 'lucide-react'; // Removed Settings
+import { PenSquare, LogIn, LogOut, UserCircle, Loader2, ShieldCheck } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { Logo } from '@/components/shared/logo';
 
@@ -28,15 +28,10 @@ export function Header() {
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6">
         <Logo />
         <nav className="flex items-center gap-2 md:gap-4">
-          <Button variant="ghost" asChild size="sm" className="px-2 md:px-3">
-            <Link href="/">
-              <Home className="mr-0 h-4 w-4 md:mr-2" /> <span className="hidden md:inline">Home</span>
-            </Link>
-          </Button>
           {user && (
-            <Button variant="ghost" asChild size="sm" className="px-2 md:px-3">
+            <Button asChild size="sm" className="px-2 md:px-3">
               <Link href="/submit">
-                <PlusSquare className="mr-0 h-4 w-4 md:mr-2" /> <span className="hidden md:inline">Submit</span>
+                <PenSquare className="mr-0 h-4 w-4 md:mr-2" /> <span className="hidden md:inline">Create Post</span>
               </Link>
             </Button>
           )}


### PR DESCRIPTION
## Summary
- simplify header navigation
- add create post button in header
- remove the community feed heading from the homepage

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_6843a34c89f483299a6f74973d44b7dc