### PR TITLE
Fix Next.js build warnings and wrap home page in Suspense

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
@@ -17,7 +17,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'GuernseySpeaks',
   description: 'A community forum for Guernsey residents.',
-  viewport: 'width=device-width, initial-scale=1',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import type { Post } from '@/types';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { PenSquare, Loader2, AlertTriangle } from 'lucide-react';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { getPosts, type GetPostsFilters } from '@/services/postService';
 import { useAuth } from '@/hooks/use-auth';
@@ -19,7 +19,7 @@ import { Card, CardContent } from '@/components/ui/card';
 // Define the canonical list of flairs
 const PREDEFINED_FLAIRS = ["Events", "News", "Discussion", "Casual", "Help", "Local Issue", "Question", "Recommendation", "Miscellaneous"];
 
-export default function HomePage() {
+function HomePageContent() {
   const [allFetchedPosts, setAllFetchedPosts] = useState<Post[]>([]);
   const [displayedPosts, setDisplayedPosts] = useState<Post[]>([]);
   const [loadingPosts, setLoadingPosts] = useState(true);
@@ -155,5 +155,13 @@ export default function HomePage() {
         </div>
       )}
     </MainLayout>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense>
+      <HomePageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- avoid deprecated viewport metadata in `layout.tsx`
- create separate `viewport` export
- wrap home page component in `<Suspense>` to satisfy Next.js build

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e21d7b848329a276bde803cf3056