### PR TITLE
Wrap header in Suspense

### DIFF
--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -1,5 +1,6 @@
 
 import { Header } from '@/components/layout/header';
+import { Suspense } from 'react';
 import { Footer } from '@/components/layout/footer';
 import type { ReactNode } from 'react';
 import { NewsHeadlinesWidget } from '@/components/news-headlines-widget'; // Import the new component
@@ -13,7 +14,9 @@ interface MainLayoutProps {
 export function MainLayout({ weatherWidget, children, adsWidget }: MainLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
+      <Suspense>
+        <Header />
+      </Suspense>
       <div className="container mx-auto flex flex-1 flex-col px-4 sm:px-6 py-6 md:flex-row md:gap-6">
         {/* Left Sidebar Section - Weather and News */}
         <aside className="mb-6 w-full md:mb-0 md:w-64 lg:w-72 xl:w-80 flex-shrink-0 rounded-lg p-4 md:sticky md:top-20 md:max-h-[calc(100vh-6rem)] md:overflow-y-auto space-y-6">


### PR DESCRIPTION
## Summary
- wrap `Header` component in a `<Suspense>` boundary so pages like `/admin` build successfully when `useSearchParams` is used inside header

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6847d283f2c48329add17392ca493996