### PR TITLE
Improve post card spacing and style

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,19 +23,19 @@ body {
     --card-foreground: 215 25% 15%;
     --popover: 0 0% 100%;
     --popover-foreground: 215 25% 15%;
-    --primary: 162 70% 40%;
+    --primary: 125 25% 35%;
     --primary-foreground: 0 0% 100%;
     --secondary: 215 20% 96%;
     --secondary-foreground: 215 25% 15%;
     --muted: 210 16% 92%;
     --muted-foreground: 215 15% 40%;
-    --accent: 162 70% 40%;
+    --accent: 125 25% 35%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 70% 50%;
     --destructive-foreground: 0 0% 100%;
     --border: 215 20% 88%;
     --input: 215 20% 88%;
-    --ring: 162 70% 40%;
+    --ring: 125 25% 35%;
     
     --chart-1: 90 40% 50%; /* Lighter version of primary green */
     --chart-2: 25 70% 60%; /* Lighter terracotta */
@@ -47,12 +47,12 @@ body {
     /* Sidebar specific colors */
     --sidebar-background: 215 20% 96%;
     --sidebar-foreground: 215 25% 15%;
-    --sidebar-primary: 162 70% 40%;
+    --sidebar-primary: 125 25% 35%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 162 70% 40%;
+    --sidebar-accent: 125 25% 35%;
     --sidebar-accent-foreground: 0 0% 100%;
     --sidebar-border: 215 20% 88%;
-    --sidebar-ring: 162 70% 40%;
+    --sidebar-ring: 125 25% 35%;
   }
 
   .dark {
@@ -62,29 +62,29 @@ body {
     --card-foreground: 210 20% 98%;
     --popover: 222 47% 13%;
     --popover-foreground: 210 20% 98%;
-    --primary: 162 70% 50%;
+    --primary: 125 25% 45%;
     --primary-foreground: 222 47% 11%;
     --secondary: 215 15% 20%;
     --secondary-foreground: 210 20% 98%;
     --muted: 215 15% 25%;
     --muted-foreground: 215 20% 70%;
-    --accent: 162 70% 50%;
+    --accent: 125 25% 45%;
     --accent-foreground: 222 47% 11%;
     --destructive: 0 60% 40%;
     --destructive-foreground: 0 0% 95%;
     --border: 215 16% 30%;
     --input: 215 16% 30%;
-    --ring: 162 70% 50%;
+    --ring: 125 25% 45%;
 
     /* Dark Sidebar specific colors */
     --sidebar-background: 215 15% 20%;
     --sidebar-foreground: 210 20% 98%;
-    --sidebar-primary: 162 70% 50%;
+    --sidebar-primary: 125 25% 45%;
     --sidebar-primary-foreground: 222 47% 11%;
-    --sidebar-accent: 162 70% 50%;
+    --sidebar-accent: 125 25% 45%;
     --sidebar-accent-foreground: 222 47% 11%;
     --sidebar-border: 215 16% 30%;
-    --sidebar-ring: 162 70% 50%;
+    --sidebar-ring: 125 25% 45%;
   }
 }
 

--- a/src/components/posts/post-card.tsx
+++ b/src/components/posts/post-card.tsx
@@ -190,10 +190,10 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
     <Link href={`/post/${post.id}/${postSlug}`} className="block group">
       <Card
         className={`
-          mb-6
+          mb-4
           transition-opacity duration-500 ease-out
           ${isVisible ? 'opacity-100' : 'opacity-0'}
-          border-none shadow-none
+          shadow hover:shadow-md
           ${className}
         `}
       >

--- a/src/components/posts/post-card.tsx
+++ b/src/components/posts/post-card.tsx
@@ -288,7 +288,7 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
                 variant="ghost"
                 size="sm"
                 className={`group ${isLiked ? 'text-primary' : 'hover:text-primary'} transition-transform duration-150 active:scale-95`}
-                onClick={(e) => { e.stopPropagation(); handleLikeToggle(); }}
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleLikeToggle(); }}
                 disabled={isLiking || !user}
               >
                 {isLiking ? (
@@ -302,7 +302,7 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
                 variant="ghost"
                 size="sm"
                 className={`group ${isDisliked ? 'text-primary' : 'hover:text-primary'} transition-transform duration-150 active:scale-95`}
-                onClick={(e) => { e.stopPropagation(); handleDislikeToggle(); }}
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleDislikeToggle(); }}
                 disabled={isDisliking || !user}
               >
                 {isDisliking ? (

--- a/src/components/posts/post-list-filters.tsx
+++ b/src/components/posts/post-list-filters.tsx
@@ -69,7 +69,7 @@ export function PostListFilters({
               id="search"
               type="text"
               placeholder="Keywords, title, author..."
-              className="pl-8" // Adjusted for potential icon, though Search icon is in Label
+              className="pl-8 h-12 rounded-lg bg-secondary"
               value={searchTerm}
               onChange={(e) => onSearchTermChange(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') onApplyFilters(); }}


### PR DESCRIPTION
## Summary
- reduce space between post cards and add subtle shadows
- enlarge search bar with a light background
- switch primary/accent theme colors to Guernsey Green

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6848381cc6c08329b1d58a56524f254d