### PR TITLE
Fill like/dislike icons when active

### DIFF
--- a/src/app/post/[id]/[slug]/page.tsx
+++ b/src/app/post/[id]/[slug]/page.tsx
@@ -367,11 +367,11 @@ function CommentCard({ commentNode, postId, onCommentDeleted, onCommentEdited, o
       <div className="mt-2 px-1">
         <div className="flex items-center">
             <Button variant="ghost" size="sm" className={`group -ml-2 ${isCommentLiked ? 'text-primary' : 'text-muted-foreground hover:text-primary'} transition-transform duration-150 active:scale-95`} onClick={handleCommentLikeToggle} disabled={isCommentLiking}>
-                {isCommentLiking ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ThumbsUp className="mr-1.5 h-4 w-4" />}
+                {isCommentLiking ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ThumbsUp className={`mr-1.5 h-4 w-4 ${isCommentLiked ? 'fill-current' : ''}`} />}
                 {comment.likes}
             </Button>
             <Button variant="ghost" size="sm" className={`group ${isCommentDisliked ? 'text-primary' : 'text-muted-foreground hover:text-primary'} transition-transform duration-150 active:scale-95`} onClick={handleCommentDislikeToggle} disabled={isCommentDisliking}>
-                {isCommentDisliking ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ThumbsDown className="mr-1.5 h-4 w-4" />}
+                {isCommentDisliking ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ThumbsDown className={`mr-1.5 h-4 w-4 ${isCommentDisliked ? 'fill-current' : ''}`} />}
                 {comment.dislikes}
             </Button>
             {user && (

--- a/src/components/posts/post-card.tsx
+++ b/src/components/posts/post-card.tsx
@@ -294,7 +294,7 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
                 {isLiking ? (
                   <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
                 ) : (
-                  <ThumbsUp className="mr-1.5 h-4 w-4" />
+                  <ThumbsUp className={`mr-1.5 h-4 w-4 ${isLiked ? 'fill-current' : ''}`} />
                 )}
                 {post.likes}
               </Button>
@@ -308,7 +308,7 @@ export function PostCard({ post: initialPost, onPostDeleted, className, staggerI
                 {isDisliking ? (
                   <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
                 ) : (
-                  <ThumbsDown className="mr-1.5 h-4 w-4" />
+                  <ThumbsDown className={`mr-1.5 h-4 w-4 ${isDisliked ? 'fill-current' : ''}`} />
                 )}
                 {post.dislikes}
               </Button>


### PR DESCRIPTION
## Summary
- make like and dislike icons fill with colour on posts
- make like and dislike icons fill with colour on comments

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68483d9af488832996e2d113dba458bf