### PR TITLE
Fix mobile ad placement and comment actions

### DIFF
--- a/src/app/post/[id]/[slug]/page.tsx
+++ b/src/app/post/[id]/[slug]/page.tsx
@@ -392,7 +392,7 @@ function CommentCard({ commentNode, postId, onCommentDeleted, onCommentEdited, o
                 className="pr-10 text-sm min-h-[40px]"
                 disabled={isSubmittingReply}
               />
-              <label htmlFor={`reply-image-${comment.id}`} className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-primary">
+              <label htmlFor={`reply-image-${comment.id}`} className="absolute bottom-2 right-2 cursor-pointer text-muted-foreground hover:text-primary">
                 <ImageIcon className="h-4 w-4" />
               </label>
               <input id={`reply-image-${comment.id}`} type="file" accept="image/*" onChange={handleReplyImageChange} className="sr-only" />
@@ -913,7 +913,7 @@ export default function PostPage({ params }: { params: PostPageParams }) {
                       <>
                         <label
                           htmlFor="new-comment-image"
-                          className="absolute right-20 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-primary"
+                          className="absolute bottom-2 right-20 cursor-pointer text-muted-foreground hover:text-primary"
                         >
                           <ImageIcon className="h-5 w-5" />
                         </label>
@@ -931,7 +931,7 @@ export default function PostPage({ params }: { params: PostPageParams }) {
                         type="submit"
                         size="sm"
                         disabled={!newComment.trim() || isSubmittingComment}
-                        className="absolute right-2 top-1/2 -translate-y-1/2 h-7 px-3"
+                        className="absolute bottom-2 right-2 h-7 px-3"
                       >
                         {isSubmittingComment ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Send className="mr-1 h-4 w-4" />}
                         Post

--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -30,12 +30,16 @@ export function MainLayout({ weatherWidget, children, adsWidget }: MainLayoutPro
           <div className="hidden md:block">
             {weatherWidget}
           </div>
-          {/* Weather wrapped in accordion on mobile */}
+          {/* Widgets wrapped in accordion on mobile */}
           <div className="md:hidden">
             <Accordion type="single" collapsible>
               <AccordionItem value="weather">
                 <AccordionTrigger>Weather</AccordionTrigger>
                 <AccordionContent>{weatherWidget}</AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="ads">
+                <AccordionTrigger>Advertisements</AccordionTrigger>
+                <AccordionContent>{adsWidget}</AccordionContent>
               </AccordionItem>
             </Accordion>
           </div>
@@ -51,10 +55,6 @@ export function MainLayout({ weatherWidget, children, adsWidget }: MainLayoutPro
         <aside className="mt-6 hidden w-full md:mt-0 md:block md:w-64 lg:w-72 xl:w-80 flex-shrink-0 rounded-lg p-4 md:sticky md:top-20 md:max-h-[calc(100vh-6rem)] md:overflow-y-auto">
           {adsWidget}
         </aside>
-      </div>
-      {/* Mobile Bottom Ad Banner */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 border-t bg-background p-4">
-        {adsWidget}
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- move ads to accordion on mobile and remove bottom banner
- position comment actions at bottom-right of textarea

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684bf321aa4c8329bafdefc6dc49e6d0